### PR TITLE
fix: add `healthycheck` for Godwoken readonly node services

### DIFF
--- a/.github/workflows/readonly-node-sync.yml
+++ b/.github/workflows/readonly-node-sync.yml
@@ -1,0 +1,93 @@
+name: Sync Test
+
+on:
+  push:
+
+jobs:
+  gw-testnet_v1-readonly-node-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Cache chain-data
+      uses: actions/cache@v3
+      with:
+        path: |
+          testnet_v1/chain-data/readonly
+        key: chain-data-${{ hashFiles('testnet_v1/docker-compose.yml') }}-${{ github.sha }}
+        restore-keys: |
+          chain-data-${{ hashFiles('testnet_v1/docker-compose.yml') }}
+
+    - name: Run a Godwoken testnet_v1 readonly node
+      working-directory: testnet_v1
+      run: |
+        cat docker-compose.yml
+        docker-compose up -d gw-testnet_v1-readonly
+
+    - name: Wait until Godwoken readonly node is ready to serve
+      id: gw-readonly-node
+      working-directory: testnet_v1
+      run: |
+        echo "Wait until Godwoken readonly node is ready to serve"
+        timeout 5h bash -c 'while true; do
+          docker-compose logs --tail 10 | egrep "sync new block" | tail --lines=1
+          docker-compose ps gw-testnet_v1-readonly | egrep healthy && break \
+          || echo "Godwoken readonly node is not healthy."
+          sleep 6s
+        done'
+        docker-compose ps gw-testnet_v1-readonly | egrep healthy \
+        && echo "::set-output name=state::healthy" 
+
+    - name: Start Godwoken Web3 and Indexer services if Godwoken readonly node is ready
+      if: steps.gw-readonly-node.outputs.state == 'healthy'
+      id: up
+      working-directory: testnet_v1
+      run: |
+        docker-compose up -d
+        timeout 1h bash -c 'while true; do
+          docker-compose ps web3 | egrep healthy && break \
+          || echo "Godwoken Web3 RPC is not healthy."
+          sleep 6s
+        done'
+        docker-compose ps web3-indexer | egrep Up \
+        && echo "::set-output name=web3::true" 
+
+    - uses: actions/checkout@v3
+      with:
+        repository: nervosnetwork/godwoken-tests
+        ref: v1
+        path: godwoken-tests
+        submodules: 'true'
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+        # cache: 'yarn'
+    - run: yarn install
+      working-directory: godwoken-tests/tools
+    - name: Check if web3 service is ready
+      if: steps.up.outputs.web3 == 'true'
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { getTipBlockNumber } = require("./godwoken-tests/scripts/helper");
+          const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+          const PUBLIC_WEB3_RPC='https://godwoken-testnet-web3-v1-rpc.ckbapp.dev';
+          while (await getTipBlockNumber() !== await getTipBlockNumber(PUBLIC_WEB3_RPC)) {
+            await sleep(6666);
+          }
+
+    - name: Save logs
+      if: always()
+      working-directory: testnet_v1
+      run: |
+        docker-compose logs --tail 66
+        docker-compose stop
+        docker-compose logs > /tmp/docker.log
+    - name: Archive logs
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: docker-logs
+        path: |
+          /tmp/docker.log

--- a/testnet_v1/README.md
+++ b/testnet_v1/README.md
@@ -7,7 +7,14 @@
 cd testnet_v1
 # Note: It is better to run your own CKB testnet node first.
 # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
-docker-compose up
+docker-compose up -d gw-testnet_v1-readonly
+
+echo "Wait until Godwoken readonly node is ready to serve"
+watch -n 6 "docker-compose ps && docker-compose logs --tail 10 | egrep 'sync new block'" 
+
+# if the status of gw-testnet_v1-readonly service is healthy,
+# then Start Godwoken Web3 and Indexer services
+docker-compose up -d
 ```
 
 ## Web3 RPC

--- a/testnet_v1/docker-compose.yml
+++ b/testnet_v1/docker-compose.yml
@@ -45,7 +45,9 @@ services:
 
   web3:
     image: ghcr.io/nervosnetwork/godwoken-web3-prebuilds:compatibility-breaking-changes-8e38985
-    volumes: 
+    healthcheck:
+      test: curl http://127.0.0.1:3000 || exit 1
+    volumes:
     - ./web3.env:/godwoken-web3/packages/api-server/.env
     working_dir: /godwoken-web3
     command: bash -c 'set -ex ; yarn run build && yarn run start:prod'

--- a/testnet_v1/docker-compose.yml
+++ b/testnet_v1/docker-compose.yml
@@ -1,10 +1,16 @@
+# Requires docker-compose >= 1.29.0
 version: '3.8'
 
 services:
   gw-testnet_v1-readonly:
     container_name: gw-testnet_v1-readonly
-    # image: ghcr.io/flouse/godwoken-prebuilds:v1.0.x
     image: ghcr.io/flouse/godwoken-prebuilds:v1.0.x-202203110200
+    healthcheck:
+      test: curl http://127.0.0.1:8119 || exit 1
+      start_period: 3s
+      interval: 6s
+      timeout: 12s
+      retries: 60
     working_dir: /deploy
     volumes:
     - ./chain-data/readonly/:/mnt/
@@ -51,10 +57,6 @@ services:
     - gw-testnet_v1-readonly
 
   web3-indexer:
-    deploy:
-      restart_policy:
-        delay: 60s
-        max_attempts: 3
     image: ghcr.io/nervosnetwork/godwoken-web3-indexer-prebuilds:compatibility-breaking-changes-94e2025
     volumes: 
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
@@ -66,7 +68,7 @@ services:
       web3:
         condition: service_started
       gw-testnet_v1-readonly:
-        condition: service_started
+        condition: service_healthy
       postgres:
         condition: service_started
       redis:

--- a/testnet_v1/docker-compose.yml
+++ b/testnet_v1/docker-compose.yml
@@ -4,19 +4,19 @@ version: '3.8'
 services:
   gw-testnet_v1-readonly:
     container_name: gw-testnet_v1-readonly
-    image: ghcr.io/flouse/godwoken-prebuilds:v1.0.x-202203110200
+    image: ghcr.io/nervosnetwork/godwoken-prebuilds:v1.0.x-202204021030
     healthcheck:
-      test: curl http://127.0.0.1:8119 || exit 1
-      start_period: 3s
-      interval: 6s
-      timeout: 12s
-      retries: 60
+      test: /healthcheck.sh
+      start_period: 10s
+      interval: 30s
+      retries: 100000
     working_dir: /deploy
     volumes:
     - ./chain-data/readonly/:/mnt/
     - ./gw-testnet_v1-config-readonly.toml:/deploy/config.toml
     - ./db.toml:/deploy/db.toml:ro
     - ./block_producer_pk:/deploy/pk:ro
+    - ./healthcheck.sh:/healthcheck.sh:ro
     environment:
     # other log envs: ,gw_generator=debug,gw_chain=debug
     - RUST_LOG=info

--- a/testnet_v1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1/gw-testnet_v1-config-readonly.toml
@@ -143,7 +143,7 @@ execute_l2tx_max_cycles = 100000000
 restore_path = '/mnt/mem-pool/mem-block'
 
 [store]
-path = '/mnt/store20220320.db'
+path = '/mnt/store20220402.db'
 options_file = '/deploy/db.toml'
 cache_size = 536870912
 

--- a/testnet_v1/healthcheck.sh
+++ b/testnet_v1/healthcheck.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Query whether a Godwoken readonly node is ready to serve
+# see: https://github.com/nervosnetwork/godwoken/pull/644
+echo '{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "method": "gw_get_mem_pool_state_ready",
+  "params": []
+}' \
+| tr -d '\n' \
+| curl --silent -H 'content-type: application/json' -d @- \
+http://127.0.0.1:8119 \
+| awk 'BEGIN { FS=":"; RS="," }; { if ($1 == "\"result\"") {print $2} }' \
+| egrep true || exit 1


### PR DESCRIPTION
- fix #21 

- The `web3-indexer` should start after the godwoken-readonly-node synced to Tip Block.
   We use `gw_get_mem_pool_state_ready` RPC to Query whether a Godwoken readonly node is ready to serve.
   see: https://github.com/nervosnetwork/godwoken/pull/644

- [chore(CI): add readonly-node-sync workflow](https://github.com/nervosnetwork/godwoken-info/pull/22/commits/972ad55e13726118ebbd424ba3fee4ef4d3bf6cf)
   We could use this GitHub action workflow to test godwoken readonly node syncing.