### PR TITLE
testnet_v0: update withdrawal_lock and state_validator

### DIFF
--- a/testnet_v0/config/scripts-deploy-result.json
+++ b/testnet_v0/config/scripts-deploy-result.json
@@ -23,7 +23,7 @@
     "script_type_hash": "0x170ef156e9f6132dbca6069dfd3e436f7d91c29d3ac7332c4b33e633b6a299b5",
     "cell_dep": {
       "out_point": {
-        "tx_hash": "0xb4b07dcd1571ac18683b515ada40e13b99bd0622197b6817047adc9f407f4828",
+        "tx_hash": "0xa8c2fe2aaaf405b2b1fd33dd63adc4c514a3d1f6dd1a64244489ad75c51a5d14",
         "index": "0x0"
       },
       "dep_type": "code"
@@ -53,7 +53,7 @@
     "script_type_hash": "0x5c365147bb6c40e817a2a53e0dec3661f7390cc77f0c02db138303177b12e9fb",
     "cell_dep": {
       "out_point": {
-        "tx_hash": "0x850e6c33d845356163c736bf8234856de0b0a8e2ad0c5227fc12058b8b602623",
+        "tx_hash": "0x0540a93f11a098c53ffceae0f7d635007de3f84096a5de45ffd75ca7cc635c34",
         "index": "0x0"
       },
       "dep_type": "code"


### PR DESCRIPTION
Update withdrawal_lock and state_validator to support [fast withdrawal from v0 to v1].

## [Godwoken Testnet Bridge](https://testnet.bridge.godwoken.io/#/v0)

To withdraw assets from Godwoken v0 to Godwoken v1:
In the [Godwoken Bridge Withdrawal UI](https://testnet.bridge.godwoken.io/#/v0), choose the destination that you want to move the assets into, then click Request Withdrawal.
![image](https://user-images.githubusercontent.com/1297478/168955344-73a41a79-d867-4e69-9b2f-a79ab59d3b98.png)




## Related PR
- https://github.com/nervosnetwork/godwoken/pull/645