### PR TITLE
testnet_v1: switch to Polyjuice 1.2.0 at block#110000

### DIFF
--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   gw-readonly:
     container_name: gw-testnet_v1.1-readonly
-    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.2.0-rc1-202206110717
+    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.2.0-rc1
     expose: [8119, 8219]
     depends_on: [ckb-testnet-indexer]
     healthcheck:

--- a/testnet_v1_1/gw-testnet_v1.1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1.1-config-readonly.toml
@@ -39,18 +39,17 @@ validator_script_type_hash = '0xa30dcbb83ebe571f49122d8d1ce4537679ebf511261c8ffa
 backend_type = 'EthAddrReg'
 [[backend_switches.backends]]
 validator_path = '/scripts/godwoken-polyjuice-v1.1.5-beta/validator'
-generator_path = '/scripts/godwoken-polyjuice-v1.1.5-beta/generator_log'
+generator_path = '/scripts/godwoken-polyjuice-v1.1.5-beta/generator'
 validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
 backend_type = 'Polyjuice'
 
-# TODO
-# [[backend_switches]]
-# switch_height = 110000
-# [[backend_switches.backends]]
-# validator_path = '/scripts/godwoken-polyjuice/validator'
-# generator_path = '/scripts/godwoken-polyjuice/generator_log'
-# validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
-# backend_type = 'Polyjuice'
+[[backend_switches]]
+switch_height = 110000
+[[backend_switches.backends]]
+validator_path = '/scripts/godwoken-polyjuice-v1.2.0/validator'
+generator_path = '/scripts/godwoken-polyjuice-v1.2.0/generator'
+validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
+backend_type = 'Polyjuice'
 
 [genesis]
 timestamp = 1651979802446


### PR DESCRIPTION
## Changed configs
```TOML
[[backend_switches]]
switch_height = 0
[[backend_switches.backends]]
validator_path = '/scripts/godwoken-scripts/meta-contract-validator'
generator_path = '/scripts/godwoken-scripts/meta-contract-generator'
validator_script_type_hash = '0x37b25df86ca495856af98dff506e49f2380d673b0874e13d29f7197712d735e8'
backend_type = 'Meta'
[[backend_switches.backends]]
validator_path = '/scripts/godwoken-scripts/sudt-validator'
generator_path = '/scripts/godwoken-scripts/sudt-generator'
validator_script_type_hash = '0xb6176a6170ea33f8468d61f934c45c57d29cdc775bcd3ecaaec183f04b9f33d9'
backend_type = 'Sudt'
[[backend_switches.backends]]
validator_path = '/scripts/godwoken-scripts/eth-addr-reg-validator'
generator_path = '/scripts/godwoken-scripts/eth-addr-reg-generator'
validator_script_type_hash = '0xa30dcbb83ebe571f49122d8d1ce4537679ebf511261c8ffaaa6679bf9fdea3a4'
backend_type = 'EthAddrReg'
[[backend_switches.backends]]
validator_path = '/scripts/godwoken-polyjuice-v1.1.5-beta/validator'
generator_path = '/scripts/godwoken-polyjuice-v1.1.5-beta/generator'
validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
backend_type = 'Polyjuice'

[[backend_switches]]
switch_height = 110000
[[backend_switches.backends]]
validator_path = '/scripts/godwoken-polyjuice/validator'
generator_path = '/scripts/godwoken-polyjuice/generator'
validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
backend_type = 'Polyjuice'
```

### Related PRs
- https://github.com/nervosnetwork/godwoken/pull/713
- https://github.com/nervosnetwork/godwoken/pull/722