### PR TITLE
testnet_v1: Bump godwoken-prebuilds to 1.2.2-rc1

### DIFF
--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   gw-readonly:
     container_name: gw-testnet_v1.1-readonly
-    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.2.0-rc1
+    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.2.2-rc1
     expose: [8119, 8219]
     depends_on: [ckb-testnet-indexer]
     healthcheck:


### PR DESCRIPTION
https://github.com/nervosnetwork/godwoken/releases/tag/v1.2.2