### PR TITLE
Bump Godwoken Web3 to v1.5.2-rc1

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.5.1-rc3
+    image: nervos/godwoken-web3-prebuilds:v1.5.2-rc1
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -60,7 +60,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.5.1-rc3
+    image: nervos/godwoken-web3-indexer-prebuilds:v1.5.2-rc1
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer

--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.5.0-rc1
+    image: nervos/godwoken-web3-prebuilds:v1.5.2-rc1
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -63,7 +63,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.5.0-rc1
+    image: nervos/godwoken-web3-indexer-prebuilds:v1.5.2-rc1
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer


### PR DESCRIPTION
## Release note
- https://github.com/nervosnetwork/godwoken-web3/releases/tag/v1.5.2-rc1

> **Note**:
The `eth-tx-hash` data field in `web3-indexer-database`(PostgreSQL) could previously contain incorrect data. This problem was fixed in v1.5.1-rc1, so data indexed by web3_version >= v1.5.1-rc1 is OK. Otherwise, you need to consider re-async database from scratch, or use the provided CLI tool to correct wrong data. 
See: https://github.com/nervosnetwork/godwoken-web3/blob/1.5-rc/packages/api-server/cli/README.md

### Use the provided CLI tool
```bash
# Run `bash` in godwoken-web3 container
cd /godwoken-web3

yarn run cli list-wrong-eth-tx-hashes --help
yarn run cli list-wrong-eth-tx-hashes

yarn run cli fix-eth-tx-hash --help
yarn run cli fix-eth-tx-hash
```

