### PR TITLE
mainnet_v1: Bump to Godwoken v1.5.0 and Web3 v1.6.2

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.9'
 services:
   gw-readonly:
     container_name: gw-mainnet_v1-readonly
-    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.4.3
+    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.5.0
     expose: [8119, 8219]
     healthcheck:
       test: /bin/healthcheck.sh
@@ -42,7 +42,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.5.2-rc1
+    image: nervos/godwoken-web3-prebuilds:v1.6.2
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -59,7 +59,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.5.2-rc1
+    image: nervos/godwoken-web3-indexer-prebuilds:v1.6.2
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer

--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.5.0
     expose: [8119, 8219]
     healthcheck:
-      test: /bin/healthcheck.sh
+      test: /bin/gw-healthcheck.sh
       start_period: 10s
       interval: 30s
       retries: 100

--- a/mainnet_v1/gw-mainnet_v1-config-readonly.toml
+++ b/mainnet_v1/gw-mainnet_v1-config-readonly.toml
@@ -138,6 +138,19 @@ restore_path = '/mnt/mem_block'
 max_deposits = 100
 max_withdrawals = 100
 max_txs = 1500
+# Introduce max_cycles_limit of a Godwoken block
+# https://github.com/nervosnetwork/godwoken/pull/767
+max_cycles_limit = '1950000000'
+[mem_pool.mem_block.syscall_cycles]
+sys_store_cycles = 50000
+sys_load_cycles = 50000
+sys_create_cycles = 50000
+sys_load_account_script_cycles = 50000
+sys_store_data_cycles = 50000
+sys_load_data_cycles = 50000
+sys_get_block_hash_cycles = 50000
+sys_recover_account_cycles = 50000
+sys_log_cycles = 50000
 
 [store]
 path = '/mnt/mainnet_v1-store.db'

--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.5-rc
     expose: [8119, 8219]
     healthcheck:
-      test: /bin/healthcheck.sh
+      test: /bin/gw-healthcheck.sh
       start_period: 10s
       interval: 30s
       retries: 100000


### PR DESCRIPTION
```sh
docker inspect ghcr.io/nervosnetwork/godwoken-prebuilds:1.5.0 | egrep ref.component

# Result
                "ref.component.ckb-production-scripts": "rc_lock 47358ce",
                "ref.component.ckb-production-scripts-sha1": "47358ceaa06274fdbde9e1f20b4f7f58313ce6e0",
                "ref.component.godwoken": "v1.5.0  66ee8fd6",
                "ref.component.godwoken-polyjuice": "1.3.0  4d068a0",
                "ref.component.godwoken-polyjuice-sha1": "4d068a0c40c02cfae5b40c7d0921a7282c19c45b",
                "ref.component.godwoken-scripts": "v1.3.0-rc1  430247e",
                "ref.component.godwoken-scripts-sha1": "430247efc62aed3e4b9b3661ade6adead0dfcbfc",
                "ref.component.godwoken-sha1": "66ee8fd6b5056533b325c9a3a787bc34fdebbdaf",```
```

## Changes
1. Update Web3 to v1.6.2
2. Bump godwoken-prebuilds to 1.5.0
3. config: add `max_cycles_limit` for a Godwoken readonly node
   - see also: https://github.com/nervosnetwork/godwoken/pull/767


## Release notes
- https://github.com/nervosnetwork/godwoken/releases
   **feat: Introduce max_cycles_limit of a Godwoken block** 
   - https://github.com/nervosnetwork/godwoken/pull/767 
- https://github.com/nervosnetwork/godwoken-web3/releases
