### PR TITLE
Bump to Godwoken Web3 v1.6.3

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.6.2
+    image: nervos/godwoken-web3-prebuilds:v1.6.3
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -59,7 +59,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.6.2
+    image: nervos/godwoken-web3-indexer-prebuilds:v1.6.3
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer

--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.6.2
+    image: nervos/godwoken-web3-prebuilds:v1.6.3
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -62,7 +62,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.6.2
+    image: nervos/godwoken-web3-indexer-prebuilds:v1.6.3
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer


### PR DESCRIPTION
# Release note
https://github.com/nervosnetwork/godwoken-web3/releases/tag/v1.6.3

## Fix log transaction index
`log.transaction_index` was always zero when indexed after version `v1.6.0-rc1`. You need to consider re-async database from scratch, or use the provided CLI tool to correct the wrong data.

See: https://github.com/nervosnetwork/godwoken-web3/blob/1.6-rc/packages/api-server/cli/README.md

### Use the provided CLI tool

Steps：
1. Update web3-indexer
2. Update web3
3. fix web3-indexer-db：
  ```bash
    # Bash in godwoken-web3 container
    cd /godwoken-web3
  
    yarn run cli wrong-log-transaction-index-count
  # found Found xxxx wrong logs
  
    yarn run cli fix-log-transaction-index
  # uery SQL: select count(*) from "logs" where transaction_index <> (select transaction_index from transactions where hash = logs.transaction_hash)
  # Found xxxx wrong logs
  # All logs updated!
  ```



## Related PR
- https://github.com/nervosnetwork/godwoken-web3/pull/502