### PR TITLE
Web3: Add the full node RPC to forward WRITE requests

### DIFF
--- a/mainnet_v1/web3.env
+++ b/mainnet_v1/web3.env
@@ -3,4 +3,7 @@
 DATABASE_URL=postgres://your_db_user_name:your_password@postgres:5432/web3-indexer-db
 REDIS_URL=redis://redis:6379
 
-GODWOKEN_JSON_RPC=http://gw-readonly:8119
+# Godwoken fullnode RPC
+GODWOKEN_JSON_RPC=https://v1.mainnet.godwoken.io/rpc
+# Godwoken readonly node RPC
+GODWOKEN_READONLY_JSON_RPC=http://gw-readonly:8119

--- a/testnet_v1_1/web3.env
+++ b/testnet_v1_1/web3.env
@@ -3,7 +3,10 @@
 DATABASE_URL=postgres://your_db_user_name:your_password@postgres:5432/web3-indexer-db
 REDIS_URL=redis://redis:6379
 
-GODWOKEN_JSON_RPC=http://gw-readonly:8119
+# Godwoken fullnode RPC
+GODWOKEN_JSON_RPC=https://godwoken-testnet-v1.ckbapp.dev
+# Godwoken readonly node RPC
+GODWOKEN_READONLY_JSON_RPC=http://gw-readonly:8119
 
 # eth_estimateGas will add this number to result, optional, default to 0
 EXTRA_ESTIMATE_GAS=30000


### PR DESCRIPTION
If you want to make an external node receiving and handling WRITE requests such as
`eth_sendRawTransaction`, you should setup the `GODWOKEN_JSON_RPC` and
`GODWOKEN_READONLY_JSON_RPC` environments in `web3.env`. And Godwoken Web3 will
forward the WRITE requests to Godwoken full node automatically, while other READ
requests will be handled by the configured Godwoken readonly local node.