### PR TITLE
Bump to Godwoken Web3 v1.6.4

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.6.3
+    image: nervos/godwoken-web3-prebuilds:v1.6.4
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -59,7 +59,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.6.3
+    image: nervos/godwoken-web3-indexer-prebuilds:v1.6.4
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer

--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.6.3
+    image: nervos/godwoken-web3-prebuilds:v1.6.4
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -62,7 +62,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.6.3
+    image: nervos/godwoken-web3-indexer-prebuilds:v1.6.4
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer


### PR DESCRIPTION
Release note https://github.com/nervosnetwork/godwoken-web3/releases/tag/v1.6.4

## feat: Add new RPC `gw_get_pending_tx_hashes`
Get pending transaction hashes, which means a developer could get the mem_pool transactions of Godwoken.

- https://github.com/nervosnetwork/godwoken-web3/pull/484
- https://github.com/nervosnetwork/godwoken/pull/772

## Example
```sh
curl https://godwoken-testnet-v1.ckbapp.dev -X POST \
        -H "Content-Type: application/json" \
        -d '{"jsonrpc": "2.0", "method":"gw_get_pending_tx_hashes", "params": [], "id": 1}'

# Reust 
{"jsonrpc":"2.0","id":1,"result":["0x2e8785d5ad1a4753c6ab666ff31976bb9c8b2991db41f58bb66a2a512a95cdb3","0x35ea09570dd36937c7dc0cb35a04609b58e58d15ba7204e7a524709855b73bf9","0x5b02a63c07a61681cc297925dd70c1ee23b28b16bde27982548c1f46d4e1a6ff","0x95fec59a004cea6c502fd82f35749cd2a70c424a15809c01be5c4002893f823c","0xd99ba866c78df6e225ff2e2907cf9a1d6c0d392254c2de6b56f6aa0019c6fc54","0xf07497e5cd30fdfed47bfb7d7ef352b79d790b3faedc1b248f928c63aa29b535"]}
```