### PR TITLE
testnet: Bump to godwoken-prebuilds:v1.6-rc and Web3 v1.7-rc

### DIFF
--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
   gw-readonly:
     container_name: gw-testnet_v1-readonly
-    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.5-rc
+    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.6-rc
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh

--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.6.4
+    image: nervos/godwoken-web3-prebuilds:v1.7.0-rc1
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -62,7 +62,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.6.4
+    image: nervos/godwoken-web3-indexer-prebuilds:v1.7.0-rc1
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -156,11 +156,11 @@ max_txs = 1500
 max_cycles_limit = '1950000000'
 [mem_pool.mem_block.syscall_cycles]
 sys_store_cycles = 50000
-sys_load_cycles = 50000
+sys_load_cycles = 5000
 sys_create_cycles = 50000
-sys_load_account_script_cycles = 50000
+sys_load_account_script_cycles = 5000
 sys_store_data_cycles = 50000
-sys_load_data_cycles = 50000
+sys_load_data_cycles = 5000
 sys_get_block_hash_cycles = 50000
 sys_recover_account_cycles = 50000
 sys_log_cycles = 50000

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -45,9 +45,11 @@ backend_type = 'Polyjuice'
 
 [[backend_switches]]
 switch_height = 180000
+# Polyjuice v1.4 is backward compatible with Polyjuice v1.3
+# https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.0-rc
 [[backend_switches.backends]]
-validator_path = '/scripts/godwoken-polyjuice-v1.3.0/validator'
-generator_path = '/scripts/godwoken-polyjuice-v1.3.0/generator'
+validator_path = '/scripts/godwoken-polyjuice/validator'
+generator_path = '/scripts/godwoken-polyjuice/generator'
 validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
 backend_type = 'Polyjuice'
 

--- a/testnet_v1_1/web3.env
+++ b/testnet_v1_1/web3.env
@@ -3,6 +3,12 @@
 DATABASE_URL=postgres://your_db_user_name:your_password@postgres:5432/web3-indexer-db
 REDIS_URL=redis://redis:6379
 
+# If you want to make an external node receiving and handling WRITE requests 
+# such as `eth_sendRawTransaction`, you should setup the `GODWOKEN_JSON_RPC` and
+# `GODWOKEN_READONLY_JSON_RPC` environments in `web3.env`. And Godwoken Web3
+# will forward the WRITE requests to Godwoken full node automatically, while 
+# other READ requests will be handled by the configured Godwoken readonly local
+# node.
 # Godwoken fullnode RPC
 GODWOKEN_JSON_RPC=https://godwoken-testnet-v1.ckbapp.dev
 # Godwoken readonly node RPC


### PR DESCRIPTION
## Release notes
- Godwoken 1.6.0-rc1
   https://github.com/nervosnetwork/godwoken/releases/tag/v1.6.0-rc1
- Polyjuice 1.4.0-rc
   https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.0-rc
- Web3 1.7.0-rc
   https://github.com/nervosnetwork/godwoken-web3/releases/tag/v1.7.0-rc1

## Changed Configs
- [Switch Polyjuice backend](https://github.com/nervosnetwork/godwoken-info/pull/61/commits/5f549e70c30a83818054553eff178261dbad221c#diff-7e686c21daa843938ca4c0df5db2fe3b79bdb6e1845d19659f941f0a811e0976R48-R52)
  Polyjuice v1.4 is backward compatible with Polyjuice v1.3
- [testnet: update [mem_pool.mem_block.syscall_cycles] of a Godwoken node](https://github.com/nervosnetwork/godwoken-info/pull/61/commits/f93b4fca0ae90d5d8db5ad7a17044ae7b1218adc)