### PR TITLE
mainnet_v1: tune mem_pool.execute_l2tx_max_cycles to 150_000_000

### DIFF
--- a/mainnet_v1/gw-mainnet_v1-config-readonly.toml
+++ b/mainnet_v1/gw-mainnet_v1-config-readonly.toml
@@ -131,7 +131,7 @@ hash_type = 'data'
 args = '0x'
 
 [mem_pool]
-execute_l2tx_max_cycles = 100000000
+execute_l2tx_max_cycles = 150000000
 restore_path = '/mnt/mem_block'
 
 [mem_pool.mem_block]


### PR DESCRIPTION
Increase the value of `mem_pool.execute_l2tx_max_cycles` to avoid `VM max cycle exceeded` error.