### PR TITLE
testnet: Bump Polyjuice to 1.4.1

### DIFF
--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
   gw-readonly:
     container_name: gw-testnet_v1-readonly
-    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.6-rc
+    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.6.1
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh
@@ -45,7 +45,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.7.0-rc1
+    image: nervos/godwoken-web3-prebuilds:v1.7.0
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -62,7 +62,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.7.0-rc1
+    image: nervos/godwoken-web3-indexer-prebuilds:v1.7.0
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -45,8 +45,17 @@ backend_type = 'Polyjuice'
 
 [[backend_switches]]
 switch_height = 180000
-# Polyjuice v1.4 is backward compatible with Polyjuice v1.3
-# https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.0-rc
+# Polyjuice v1.4.0 is backward compatible with Polyjuice v1.3
+# https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.0
+[[backend_switches.backends]]
+validator_path = '/scripts/godwoken-polyjuice-v1.4.0/validator'
+generator_path = '/scripts/godwoken-polyjuice-v1.4.0/generator'
+validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
+backend_type = 'Polyjuice'
+
+[[backend_switches]]
+switch_height = 380000
+# https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.1
 [[backend_switches.backends]]
 validator_path = '/scripts/godwoken-polyjuice/validator'
 generator_path = '/scripts/godwoken-polyjuice/generator'


### PR DESCRIPTION
### Bump Polyjuice to [1.4.1](https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.1)
- Fix wrong used_gas of native transfer in polyjuice_system_log 
   https://github.com/nervosnetwork/godwoken-polyjuice/pull/179
   Due to this bug, testnet_v1 have to [switch Polyjuice backend at block#380000](https://github.com/nervosnetwork/godwoken-info/pull/64/files#diff-7e686c21daa843938ca4c0df5db2fe3b79bdb6e1845d19659f941f0a811e0976R46-R63).
   