### PR TITLE
testnet: bump to Godwoken v1.7-rc and Web3 v1.8+

### DIFF
--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
   gw-readonly:
     container_name: gw-testnet_v1-readonly
-    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.6.1
+    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.7-rc
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh
@@ -46,7 +46,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.7.0
+    image: nervos/godwoken-web3-prebuilds:v1.8.1
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -63,7 +63,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.7.0
+    image: nervos/godwoken-web3-indexer-prebuilds:v1.8.1
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -175,7 +175,7 @@ sys_recover_account_cycles = 50000
 sys_log_cycles = 50000
 
 [store]
-path = '/mnt/store-20220819.db'
+path = '/mnt/store-20221008.db'
 options_file = '/deploy/db.toml'
 cache_size = 536870912
 [store.options]


### PR DESCRIPTION
[nervosnetwork/godwoken/pull/787](https://github.com/nervosnetwork/godwoken/pull/787/files#diff-2012230f89ce71c3fc30017f5f99cfb5f38fe1ed70186cf114d264bf45d95444) introduced some schema changes. To upgrade a Godwoken readonly node to v1.7+, we need to re-sync it from the genesis block to create a new data store.

## How to re-sync a Godwoken readonly node?
1. Modify the [store.path] in `gw-testnet_v1-config-readonly.toml`
2. Update the image to `ghcr.io/nervosnetwork/godwoken-prebuilds:1.7-rc`
3. Restart the Godwoken readonly node
4. Syncing from the genesis block to the TIP will take about 11 hours.

## Release notes
- Godwoken https://github.com/nervosnetwork/godwoken/releases/tag/v1.7.0-rc1
- Godwoken Web3 https://github.com/nervosnetwork/godwoken-web3/releases/tag/v1.8.1

## Inspect the component versions in the image
```bash
docker inspect ghcr.io/nervosnetwork/godwoken-prebuilds:1.7-rc | egrep ref.component

# components
      "ref.component.ckb-production-scripts": "rc_lock 47358ce",
      "ref.component.ckb-production-scripts-sha1": "47358ceaa06274fdbde9e1f20b4f7f58313ce6e0",
      "ref.component.godwoken": "v1.7.0-rc1  e5d82c11",
      "ref.component.godwoken-polyjuice": "1.4.1  1d05a58",
      "ref.component.godwoken-polyjuice-sha1": "1d05a58e431b90cfdb785c772fe1e7a319ff2512",
      "ref.component.godwoken-scripts": "v1.3.0-rc1  430247e",
      "ref.component.godwoken-scripts-sha1": "430247efc62aed3e4b9b3661ade6adead0dfcbfc",
      "ref.component.godwoken-sha1": "e5d82c11ea655431ca64eb3c5b43bccf51ed65a7",
```

