### PR TITLE
Fix log index in web3_indexer_db

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.7.0
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.7.4
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -60,7 +60,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.7.0
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.7.4
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer

--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: nervos/godwoken-web3-prebuilds:v1.8.1
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.8.5
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -63,7 +63,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: nervos/godwoken-web3-indexer-prebuilds:v1.8.1
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.8.5
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer


### PR DESCRIPTION
## Release notes
- Godwoken Web3
   1. https://github.com/godwokenrises/godwoken-web3/releases/tag/v1.8.5
       https://github.com/godwokenrises/godwoken-web3/compare/v1.8.1...v1.8.5
       
   2. https://github.com/godwokenrises/godwoken-web3/releases/tag/v1.7.4
       https://github.com/godwokenrises/godwoken-web3/compare/v1.7.0...v1.7.4
   
---

## Note

Database migration is required to fix the log index data in this version.

### Check how many db records need to be fixed via SQL 

```sh
select count(*) from logs where (block_number, transaction_index) not in (select block_number, min(transaction_index) min_tx_index from logs group by block_number);
```
(please aware that after record fixed, this SQL will still show the same number, it is expected)


### Run migration in Web3 containner to fix database

```sh
cd /godwoken-web3
yarn knex migrate:latest
```

