### PR TITLE
testnet: bump godwoken-prebuilds to 1.7.0-rc2-poly.1.4.5

### DIFF
--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
   gw-readonly:
     container_name: gw-testnet_v1-readonly
-    image: ghcr.io/nervosnetwork/godwoken-prebuilds:1.7-rc
+    image: ghcr.io/godwokenrises/godwoken-prebuilds:1.7.0-rc2-poly.1.4.5
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -57,8 +57,17 @@ backend_type = 'Polyjuice'
 switch_height = 380000
 # https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.1
 [[backend_switches.backends]]
+validator_path = '/scripts/godwoken-polyjuice-v1.4.1/validator'
+generator_path = '/scripts/godwoken-polyjuice-v1.4.1/generator_log'
+validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
+backend_type = 'Polyjuice'
+
+[[backend_switches]]
+switch_height = 630000
+# https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.5
+[[backend_switches.backends]]
 validator_path = '/scripts/godwoken-polyjuice/validator'
-generator_path = '/scripts/godwoken-polyjuice/generator_log'
+generator_path = '/scripts/godwoken-polyjuice/generator'
 validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
 backend_type = 'Polyjuice'
 


### PR DESCRIPTION
## Notable changes
- feat: increase size limit of return data to 128k  by @magicalne in https://github.com/godwokenrises/godwoken/pull/811

## Release notes
- Godwoken https://github.com/godwokenrises/godwoken/releases/tag/v1.7.0-rc2
- Polyjuice https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.4.5

## Changed Configs
1. [add new backend switch](https://github.com/godwokenrises/godwoken-info/pull/71/files#diff-7e686c21daa843938ca4c0df5db2fe3b79bdb6e1845d19659f941f0a811e0976)

## Sync-test from genesis block
- https://github.com/Flouse/godwoken-info/actions/runs/3322098742/jobs/5490648210#step:8:12586

<!--
## Inspect the component versions in the image
```bash
docker inspect ghcr.io/nervosnetwork/godwoken-prebuilds:1.6.0 | egrep ref.component

    # components
    "ref.component.ckb-production-scripts": "rc_lock 47358ce",
    "ref.component.ckb-production-scripts-sha1": "47358ceaa06274fdbde9e1f20b4f7f58313ce6e0",
    "ref.component.godwoken": "v1.6.0  0ae11969",
    "ref.component.godwoken-polyjuice": "1.4.0  5626a05",
    "ref.component.godwoken-polyjuice-sha1": "5626a05279d0f0ad1d6e2aa0e954962b3c777134",
    "ref.component.godwoken-scripts": "v1.3.0-rc1  430247e",
    "ref.component.godwoken-scripts-sha1": "430247efc62aed3e4b9b3661ade6adead0dfcbfc",
    "ref.component.godwoken-sha1": "0ae1196976df620740ed3834f4667a722b4b65c7",
```
-->