### PR TITLE
mainnet_v1: bump to Godwoken v1.6.2 and Polyjuice v1.4.5

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.9'
 services:
   gw-readonly:
     container_name: gw-mainnet_v1-readonly
-    image: ghcr.io/godwokenrises/godwoken-prebuilds:1.6.2-rc2
+    image: ghcr.io/godwokenrises/godwoken-prebuilds:1.6.2-poly.1.4.5
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh

--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.7.4
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.8.5
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -60,7 +60,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.7.4
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.8.5
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer

--- a/mainnet_v1/gw-mainnet_v1-config-readonly.toml
+++ b/mainnet_v1/gw-mainnet_v1-config-readonly.toml
@@ -51,11 +51,20 @@ backend_type = 'Polyjuice'
 switch_height = 186758
 [[backend_switches.backends]]
 # https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.4
-# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.4.5
-validator_path = '/scripts/godwoken-polyjuice/validator'
-generator_path = '/scripts/godwoken-polyjuice/generator'
+validator_path = '/scripts/godwoken-polyjuice-v1.4.4/validator'
+generator_path = '/scripts/godwoken-polyjuice-v1.4.4/generator'
 validator_script_type_hash = '0x83d5d8841518e8db686909d27c821398491f475ed5f1cd392c36e83f4252c4ac'
 backend_type = 'Polyjuice'
+
+[[backend_switches]]
+switch_height = 204000
+[[backend_switches.backends]]
+# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.4.5
+validator_path = '/scripts/godwoken-polyjuice-v1.4.5/validator'
+generator_path = '/scripts/godwoken-polyjuice-v1.4.5/generator'
+validator_script_type_hash = '0x83d5d8841518e8db686909d27c821398491f475ed5f1cd392c36e83f4252c4ac'
+backend_type = 'Polyjuice'
+
 
 [genesis]
 timestamp = 1655830128000

--- a/mainnet_v1/gw-mainnet_v1-config-readonly.toml
+++ b/mainnet_v1/gw-mainnet_v1-config-readonly.toml
@@ -37,19 +37,21 @@ generator_path = '/scripts/godwoken-polyjuice-v1.4.1/generator'
 validator_script_type_hash = '0x83d5d8841518e8db686909d27c821398491f475ed5f1cd392c36e83f4252c4ac'
 backend_type = 'Polyjuice'
 
-[[backend_switches]]
-switch_height = 186750
-[[backend_switches.backends]]
-# https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.2
-validator_path = '/scripts/godwoken-polyjuice-v1.4.2/validator'
-generator_path = '/scripts/godwoken-polyjuice-v1.4.2/generator'
-validator_script_type_hash = '0x83d5d8841518e8db686909d27c821398491f475ed5f1cd392c36e83f4252c4ac'
-backend_type = 'Polyjuice'
+# TODO: remove the useless backend version
+# [[backend_switches]]
+# switch_height = 186750
+# [[backend_switches.backends]]
+# # https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.2
+# validator_path = '/scripts/godwoken-polyjuice-v1.4.2/validator'
+# generator_path = '/scripts/godwoken-polyjuice-v1.4.2/generator'
+# validator_script_type_hash = '0x83d5d8841518e8db686909d27c821398491f475ed5f1cd392c36e83f4252c4ac'
+# backend_type = 'Polyjuice'
 
 [[backend_switches]]
 switch_height = 186758
 [[backend_switches.backends]]
 # https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.4
+# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.4.5
 validator_path = '/scripts/godwoken-polyjuice/validator'
 generator_path = '/scripts/godwoken-polyjuice/generator'
 validator_script_type_hash = '0x83d5d8841518e8db686909d27c821398491f475ed5f1cd392c36e83f4252c4ac'


### PR DESCRIPTION
## Noteable Changes
- feat: increase size limit of return data to 128k by @magicalne in https://github.com/godwokenrises/godwoken/pull/811 
 
## Release notes
- Godwoken
   https://github.com/godwokenrises/godwoken/releases/tag/v1.6.2
- Polyjuice
   https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.4.5


## Changed Configs
1. [remove the useless backend version (Polyjuice 1.4.2)](https://github.com/godwokenrises/godwoken-info/blob/47ccb6e58499a2dba2c043c15b44c2e4bf09fb31/mainnet_v1/gw-mainnet_v1-config-readonly.toml#L40-L48)
2. [switch to polyjuice-v1.4.5 backend at block#204000, around November 1, 2022](https://github.com/godwokenrises/godwoken-info/pull/72/commits/04c6c22555206ef213b00af5f4037790579cb8a7)

## Inspect the component versions in the image
```bash
docker inspect ghcr.io/godwokenrises/godwoken-prebuilds:1.6.2-poly.1.4.5 | egrep ref.component

    # components
    "ref.component.ckb-production-scripts": "rc_lock 47358ce",
    "ref.component.ckb-production-scripts-sha1": "47358ceaa06274fdbde9e1f20b4f7f58313ce6e0",
    "ref.component.godwoken": "v1.6.2  67856e4a",
    "ref.component.godwoken-polyjuice": "1.4.5  720e6ee",
    "ref.component.godwoken-polyjuice-sha1": "720e6ee28ef9012cc7a59e76a97e0800f77d4c66",
    "ref.component.godwoken-scripts": "v1.3.0-rc1  430247e",
    "ref.component.godwoken-scripts-sha1": "430247efc62aed3e4b9b3661ade6adead0dfcbfc",
    "ref.component.godwoken-sha1": "67856e4a02baa00989e622b0fe253ecf35a88117",```
```

## Sync-test from genesis block#0
- https://github.com/Flouse/godwoken-info/actions/runs/3342803200