### PR TITLE
testnet_v1: bump godwoken-prebuilds:1.7.0-poly.1.4.5 and web3 1.8.6

### DIFF
--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
   gw-readonly:
     container_name: gw-testnet_v1-readonly
-    image: ghcr.io/godwokenrises/godwoken-prebuilds:1.7.0-rc2-poly.1.4.5
+    image: ghcr.io/godwokenrises/godwoken-prebuilds:1.7.0-poly.1.4.5
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh

--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.8.5
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.8.6
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -63,7 +63,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.8.5
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.8.6
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -172,16 +172,10 @@ max_txs = 1500
 # Introduce max_cycles_limit of a Godwoken block
 # https://github.com/nervosnetwork/godwoken/pull/767
 max_cycles_limit = '1950000000'
-[mem_pool.mem_block.syscall_cycles]
-sys_store_cycles = 50000
-sys_load_cycles = 5000
-sys_create_cycles = 50000
-sys_load_account_script_cycles = 5000
-sys_store_data_cycles = 50000
-sys_load_data_cycles = 5000
-sys_get_block_hash_cycles = 50000
-sys_recover_account_cycles = 50000
-sys_log_cycles = 50000
+
+# [mem_pool.mem_block.syscall_cycles]
+# Default SyscallCyclesConfig:
+# https://github.com/godwokenrises/godwoken/blob/v1.7.0/crates/config/src/config.rs#L579-L599
 
 [store]
 path = '/mnt/store-20221008.db'

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -166,9 +166,10 @@ execute_l2tx_max_cycles = 100000000
 restore_path = '/mnt/mem-pool/mem-block'
 
 [mem_pool.mem_block]
-max_deposits = 100
-max_withdrawals = 100
-max_txs = 1500
+max_deposits = 50
+max_withdrawals = 50
+# MAX_TPS * block_time = 40 * 8 = 320, rounded up to 400
+max_txs = 400
 # Introduce max_cycles_limit of a Godwoken block
 # https://github.com/nervosnetwork/godwoken/pull/767
 max_cycles_limit = '1950000000'


### PR DESCRIPTION
## Release notes
- Godwoken Web3
   https://github.com/godwokenrises/godwoken-web3/releases/tag/v1.8.6
- Godwoken 
   https://github.com/godwokenrises/godwoken/releases/tag/v1.7.0
   https://github.com/godwokenrises/godwoken/compare/v1.7.0-rc2...v1.7.0

## Changed Configs
> refer to the changed configuration files
1. [Use Default SyscallCyclesConfig](https://github.com/godwokenrises/godwoken-info/compare/testnet_v1?expand=1#diff-7e686c21daa843938ca4c0df5db2fe3b79bdb6e1845d19659f941f0a811e0976R175-R178)
2. [reduce max block withdrawals/deposits/txs](https://github.com/godwokenrises/godwoken-info/pull/74/commits/e93551ae5eadff847ac7fceab904f41eceabe833)

## Sync-test from genesis block
- https://github.com/Flouse/godwoken-info/actions/runs/3386738614

<!--
## Inspect the component versions in the image
```bash
docker inspect ghcr.io/nervosnetwork/godwoken-prebuilds:1.6.0 | egrep ref.component

    # components
    "ref.component.ckb-production-scripts": "rc_lock 47358ce",
    "ref.component.ckb-production-scripts-sha1": "47358ceaa06274fdbde9e1f20b4f7f58313ce6e0",
    "ref.component.godwoken": "v1.6.0  0ae11969",
    "ref.component.godwoken-polyjuice": "1.4.0  5626a05",
    "ref.component.godwoken-polyjuice-sha1": "5626a05279d0f0ad1d6e2aa0e954962b3c777134",
    "ref.component.godwoken-scripts": "v1.3.0-rc1  430247e",
    "ref.component.godwoken-scripts-sha1": "430247efc62aed3e4b9b3661ade6adead0dfcbfc",
    "ref.component.godwoken-sha1": "0ae1196976df620740ed3834f4667a722b4b65c7",
```
-->
