### PR TITLE
mainnet_v1: bump to godwoken-prebuilds:1.7.0-poly.1.4.5 and web3 1.8.6

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.9'
 services:
   gw-readonly:
     container_name: gw-mainnet_v1-readonly
-    image: ghcr.io/godwokenrises/godwoken-prebuilds:1.6.2-poly.1.4.5
+    image: ghcr.io/godwokenrises/godwoken-prebuilds:1.7.0-poly.1.4.5
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh

--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     - ./chain-data/redis-data:/data
 
   web3:
-    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.8.5
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.8.6
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -60,7 +60,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.8.5
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.8.6
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     working_dir: /var/lib/web3-indexer

--- a/mainnet_v1/gw-mainnet_v1-config-readonly.toml
+++ b/mainnet_v1/gw-mainnet_v1-config-readonly.toml
@@ -157,7 +157,7 @@ hash_type = 'data'
 args = '0x'
 
 [mem_pool]
-execute_l2tx_max_cycles = 150000000
+execute_l2tx_max_cycles = 3000000000
 restore_path = '/mnt/mem_block'
 
 [mem_pool.mem_block]
@@ -167,16 +167,10 @@ max_txs = 1500
 # Introduce max_cycles_limit of a Godwoken block
 # https://github.com/nervosnetwork/godwoken/pull/767
 max_cycles_limit = '1950000000'
-[mem_pool.mem_block.syscall_cycles]
-sys_store_cycles = 50000
-sys_load_cycles = 5000
-sys_create_cycles = 50000
-sys_load_account_script_cycles = 5000
-sys_store_data_cycles = 50000
-sys_load_data_cycles = 5000
-sys_get_block_hash_cycles = 50000
-sys_recover_account_cycles = 50000
-sys_log_cycles = 50000
+
+# [mem_pool.mem_block.syscall_cycles]
+# Default SyscallCyclesConfig:
+# https://github.com/godwokenrises/godwoken/blob/v1.7.0/crates/config/src/config.rs#L579-L599
 
 [store]
 path = '/mnt/mainnet_v1-store.db'

--- a/mainnet_v1/gw-mainnet_v1-config-readonly.toml
+++ b/mainnet_v1/gw-mainnet_v1-config-readonly.toml
@@ -161,9 +161,10 @@ execute_l2tx_max_cycles = 3000000000
 restore_path = '/mnt/mem_block'
 
 [mem_pool.mem_block]
-max_deposits = 100
-max_withdrawals = 100
-max_txs = 1500
+max_deposits = 50
+max_withdrawals = 50
+# MAX_TPS * block_time = 40 * 8 = 320, rounded up to 400
+max_txs = 400
 # Introduce max_cycles_limit of a Godwoken block
 # https://github.com/nervosnetwork/godwoken/pull/767
 max_cycles_limit = '1950000000'


### PR DESCRIPTION
## Noteable Changes
1. Decouple block producing, submission and confirming https://github.com/nervosnetwork/godwoken/pull/776
   With this feature, Godwoken `block_interval` is configurable. It means that the average_block_time of Godwoken will be stable (~45s).

> And in the next release containing [this PR](https://github.com/godwokenrises/godwoken-scripts/pull/132), we could continue to reduce the average_block_time to 8 seconds.

2. Because there are many store schema optimizations from Godwoken 1.6 to 1.7, a gw-readonly-node **need to be resynchronized** from genesis block in this upgrade.
    The most simple way to force a resync from genesis is deleting the chain-data in [store.path].
    > https://github.com/godwokenrises/godwoken-info/blob/6ede51d/mainnet_v1/gw-mainnet_v1-config-readonly.toml#L176-L177
 
## Release notes
- Godwoken Web3
   https://github.com/nervosnetwork/godwoken-web3/releases/tag/v1.8.6
- Godwoken 
   https://github.com/godwokenrises/godwoken/releases/tag/v1.7.0
   https://github.com/godwokenrises/godwoken/compare/v1.6.2...v1.7.0

## Changed Configs
Please refer to the changed configuration files.
1. [update [mem_pool.execute_l2tx_max_cycles]](https://github.com/godwokenrises/godwoken-info/pull/75/files#diff-3345f1a475e5ea009113a570692476ef28ec055ec73b49c995fee6d2d2633403R160)
2. [update [mem_pool.mem_block]](https://github.com/godwokenrises/godwoken-info/pull/75/files#diff-3345f1a475e5ea009113a570692476ef28ec055ec73b49c995fee6d2d2633403R163-R174)


## Sync-test from genesis block
- https://github.com/Flouse/godwoken-info/actions/runs/3408525183/jobs/5669216353

> **Note**: This upgrade requires re-syncing Godwoken readonly node.

<!--
## Inspect the component versions in the image
```bash
docker inspect ghcr.io/nervosnetwork/godwoken-prebuilds:1.6.0 | egrep ref.component

    # components
    "ref.component.ckb-production-scripts": "rc_lock 47358ce",
    "ref.component.ckb-production-scripts-sha1": "47358ceaa06274fdbde9e1f20b4f7f58313ce6e0",
    "ref.component.godwoken": "v1.6.0  0ae11969",
    "ref.component.godwoken-polyjuice": "1.4.0  5626a05",
    "ref.component.godwoken-polyjuice-sha1": "5626a05279d0f0ad1d6e2aa0e954962b3c777134",
    "ref.component.godwoken-scripts": "v1.3.0-rc1  430247e",
    "ref.component.godwoken-scripts-sha1": "430247efc62aed3e4b9b3661ade6adead0dfcbfc",
    "ref.component.godwoken-sha1": "0ae1196976df620740ed3834f4667a722b4b65c7",
```
-->
