### PR TITLE
testnet_v1: fix script args of GWK

### DIFF
--- a/testnet_v1_1/bridged-token-list.json
+++ b/testnet_v1_1/bridged-token-list.json
@@ -19,7 +19,7 @@
       "symbol": "GWK"
     },
     "erc20Info": {
-      "sudtScriptArgs": "0x4db75e03349f4f2ec792476035dd1b7376c683130f7e2e74024be2d9ee064511",
+      "sudtScriptArgs": "0x5c7253696786b9eddd34e4f6b6e478ec5742bd36569ec60c1d0487480ba4f9e3",
       "ethAddress": "0x2275afe815de66beabe7a2c03005537ab843afb2"
     },
     "UAN": "GWK.gw|gb.ckb",


### PR DESCRIPTION
### Noteable Changes
1. The script args of GWK token is wrong, replacing it with the correct one

### Reference
- https://github.com/Magickbase/godwoken_explorer/issues/651
