### PR TITLE
chore: replace testnet_v1 rpc url

### DIFF
--- a/testnet_v1_1/README.md
+++ b/testnet_v1_1/README.md
@@ -1,8 +1,8 @@
 ## Godwoken testnet_v1
 
 ## Godwoken Web3 RPC
-* **RPC URL**: https://godwoken-testnet-v1.ckbapp.dev
-* **WebSocket**: wss://godwoken-testnet-v1.ckbapp.dev/ws
+* **RPC URL**: https://v1.testnet.godwoken.io/rpc
+* **WebSocket**: wss://v1.testnet.godwoken.io/ws
 
 
 ## Tools
@@ -14,7 +14,7 @@
 ## Deployment information
 * **Chain ID**: 71401
 ```bash
-> curl -X POST 'https://godwoken-testnet-v1.ckbapp.dev' \
+> curl -X POST 'https://v1.testnet.godwoken.io/rpc' \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_chainId","params": [],"id":1}'
 

--- a/testnet_v1_1/web3.env
+++ b/testnet_v1_1/web3.env
@@ -10,7 +10,7 @@ REDIS_URL=redis://redis:6379
 # other READ requests will be handled by the configured Godwoken readonly local
 # node.
 # Godwoken fullnode RPC
-GODWOKEN_JSON_RPC=https://godwoken-testnet-v1.ckbapp.dev
+GODWOKEN_JSON_RPC=https://v1.testnet.godwoken.io/rpc
 # Godwoken readonly node RPC
 GODWOKEN_READONLY_JSON_RPC=http://gw-readonly:8119
 


### PR DESCRIPTION
Godwoken has a new Testnet RPC url, replacing it:
- `https://godwoken-testnet-v1.ckbapp.dev` -> `https://v1.testnet.godwoken.io/rpc`
- `wss://godwoken-testnet-v1.ckbapp.dev` -> `wss://v1.testnet.godwoken.io/ws`