### PR TITLE
mainnet_v1: bump to godwoken-prebuilds 1.7.3 and web3/indexer 1.9.0

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -1,10 +1,14 @@
 # Requires docker-compose >= 1.29.0
 version: '3.9'
 
+volumes:
+  mainnet_v1-web3-indexer-data:
+  mainnet_v1-redis-data:
+
 services:
   gw-readonly:
     container_name: gw-mainnet_v1-readonly
-    image: ghcr.io/godwokenrises/godwoken-prebuilds:1.7.1-poly1.5.0
+    image: ghcr.io/godwokenrises/godwoken-prebuilds:1.7.3
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh
@@ -34,16 +38,16 @@ services:
       POSTGRES_USER: your_db_user_name
       POSTGRES_PASSWORD: your_password
     volumes:
-    - ./chain-data/postgresql/data:/var/lib/postgresql/data
+    - mainnet_v1-web3-indexer-data:/var/lib/postgresql/data
   
   redis:
     image: redis:bullseye
     user: redis:redis
     volumes:
-    - ./chain-data/redis-data:/data
+    - mainnet_v1-redis-data:/data
 
   web3:
-    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.8.6
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.9.0
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -60,9 +64,15 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.8.6
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.9.0
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
+    - ./chain-data/logs:/var/lib/web3-indexer/logs
+    # How te-sync web3-indexer at /var/lib/web3-indexer/ ?
+    # ➜ nohup gw-web3-indexer update <startBlock> <endBlock> > logs/web3-indexer-update.log 2>&1 &
+    # or
+    # ➜ nohup gw-web3-indexer update > logs/web3-indexer-update.log 2>&1 &
+    # refer to: https://github.com/godwokenrises/godwoken-web3/blob/main/README.md#update-blocks
     working_dir: /var/lib/web3-indexer
     command: [ "gw-web3-indexer" ]
     environment:

--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -75,6 +75,7 @@ services:
     # refer to: https://github.com/godwokenrises/godwoken-web3/blob/main/README.md#update-blocks
     working_dir: /var/lib/web3-indexer
     command: [ "gw-web3-indexer" ]
+    restart: unless-stopped
     environment:
     - RUST_LOG=info
     depends_on:


### PR DESCRIPTION
## Notable Changes
1. fixed https://github.com/godwokenrises/godwoken-web3/issues/566
    **Note**: Need to re-sync web3-indexer or run update command by `./gw-web3-indexer update`
2. https://github.com/godwokenrises/godwoken-web3/pull/570
3. fix: use mem-pool state for “get block” RPCs by @sopium in https://github.com/godwokenrises/godwoken/pull/871
4. config: deny unknown fields in the config toml file https://github.com/godwokenrises/godwoken/pull/862


## Release notes
- Godwoken Web3
   https://github.com/godwokenrises/godwoken-web3/releases/tag/v1.9.0
- [Godwoken](https://github.com/godwokenrises/godwoken/releases) 
  https://github.com/godwokenrises/godwoken/releases/tag/v1.7.2
  https://github.com/godwokenrises/godwoken/releases/tag/v1.7.3
  Full Changelog: https://github.com/godwokenrises/godwoken/compare/v1.7.1...v1.7.3


## Re-sync web3-indexer or run update command by `./gw-web3-indexer update`
**Database fixing is required for this release.**

Rather than doing a re-sync in web3-indexer, we provides a new command in web3-indexer to update the whole database:
```bash
pwd
# godwoken-info/mainnet_v1

docker-compose exec web3-indexer
nohup gw-web3-indexer update > logs/web3-indexer-update.log 2>&1 &

## watch the progress in the container
tail -f logs/web3-indexer-update.log

## watch the progress outside the container
tail -f chain-data/logs/web3-indexer-update.log
```
