### PR TITLE
mainnet_v1: sync some configs in web3.env from fullnode

### DIFF
--- a/mainnet_v1/web3.env
+++ b/mainnet_v1/web3.env
@@ -13,3 +13,23 @@ REDIS_URL=redis://redis:6379
 GODWOKEN_JSON_RPC=https://v1.mainnet.godwoken.io/rpc
 # Godwoken readonly node RPC
 GODWOKEN_READONLY_JSON_RPC=http://gw-readonly:8119
+
+# configs about cache
+ENABLE_CACHE_ETH_CALL=true
+ENABLE_CACHE_ESTIMATE_GAS=true
+ENABLE_CACHE_EXECUTE_RAW_L2_TX=true
+
+# eth_estimateGas will add this number to result, optional, default to 0
+EXTRA_ESTIMATE_GAS=28000
+
+# ENABLE_PRICE_ORACLE=<optional, boolean, decide if use dynamic gas price based on CKB price oracle, default to false>
+# GAS_PRICE_DIVIDER=<optional, a system value to adjust gasPrice with ckbPrice, default to 76000000000000000 (0.00002pCKB with 0.0038 ckb price)>
+# **MIN_GAS_PRICE = GAS_PRICE_DIVIDER / ckbPrice**
+# see also: https://github.com/nervosnetwork/godwoken-web3/pull/514
+ENABLE_PRICE_ORACLE=false
+GAS_PRICE_DIVIDER=150000000000000000
+# uint pCKB, equals 4000 shannon/gas, , should be the same value as Godwoken fullnode
+MIN_GAS_PRICE_LOWER_LIMIT=0.00004
+# uint pCKB, equals 4000 shannon/gas
+MIN_GAS_PRICE_UPPER_LIMIT=0.00004
+# The range of MIN_GAS_PRICE = [0.00004 pCKB, 0.00004 pCKB]


### PR DESCRIPTION
## Related PR
- https://github.com/godwokenrises/godwoken-info/pull/59


## Changed Configs
If we want a Godwoken readonly node to handle `eth_sendRawTransaction` requests, a.k.a forward WRITE requests to Godwoken fullnode, some additional configurations are required.

1. add `eth_estimateGas` into web3.env
2. add `MIN_GAS_PRICE_LOWER_LIMIT` into web3.env

<!--
## Inspect the component versions in the image
```bash
docker inspect ghcr.io/godwokenrises/godwoken-prebuilds:xxxx | egrep ref.component

    # components
    ...
```
-->
