### PR TITLE
update p2p config

### DIFF
--- a/mainnet_v1/gw-mainnet_v1-config-readonly.toml
+++ b/mainnet_v1/gw-mainnet_v1-config-readonly.toml
@@ -10,8 +10,8 @@ ckb_url = 'https://mainnet.ckb.dev/rpc'
 listen = '0.0.0.0:8119'
 enable_methods = []
 
-# [p2p_network_config]
-# dial = ["/dns4/godwoken/tcp/9999"]
+[p2p_network_config]
+dial = ["/dns4/mainnet.p2p.godwoken.io/tcp/9999"]
 
 
 [fork]

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -2,6 +2,11 @@ node_mode = 'readonly'
 
 # To achieve higher sync speed, please run your own ckb-testnet-node and ckb-testnet-indexer
 # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
+[p2p_network_config]
+# The domain name here should resolve to the IPv4 address of the full node.
+# And obviously readonly nodes need to be able to reach the TCP 8999 port of the full node.
+dial = ["/dns4/testnet.p2p.godwoken.io/tcp/8999"]
+
 [rpc_client]
 # Public Nodes (rate_limit: 20 req/s)
 ckb_url = 'https://testnet.ckbapp.dev/rpc'


### PR DESCRIPTION

## Changed Configs
You can connect to fullnode through a p2p port for synchronization
1. add `p2p_network_config` into gw-testnet_v1-config-readonly.toml

<!--
## Inspect the component versions in the image
```bash
docker inspect ghcr.io/godwokenrises/godwoken-prebuilds:xxxx | egrep ref.component

    # components
    ...
```
-->
