### PR TITLE
testnet: bump to godwoken v1.8.0-rc3 and web3/indexer v1.10.0-rc1

### DIFF
--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
   gw-readonly:
     container_name: gw-testnet_v1-readonly
-    image: ghcr.io/godwokenrises/godwoken-prebuilds:1.7.3
+    image: ghcr.io/godwokenrises/godwoken:v1.8.0-rc3
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh
@@ -50,7 +50,7 @@ services:
     - testnet_v1-redis-data:/data
 
   web3:
-    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.9.0
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.10.0-rc1
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -67,7 +67,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.9.0
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.10.0-rc1
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     - ./chain-data/logs:/var/lib/web3-indexer/logs

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -5,12 +5,18 @@ node_mode = 'readonly'
 # And obviously readonly nodes need to be able to reach the TCP 8999 port of the full node.
 dial = ["/dns4/testnet.p2p.godwoken.io/tcp/8999"]
 
+# To achieve higher sync speed, please run your own ckb-testnet-node
+# see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
+# Cmd `ckb run --indexer` could enable built-in indexer of a ckb node.
 [rpc_client]
 # Public Nodes (rate_limit: 20 req/s)
-# To achieve higher sync speed, please run your own ckb-testnet-node and ckb-testnet-indexer
-# see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
 ckb_url = 'https://testnet.ckbapp.dev/rpc'
-indexer_url = 'https://testnet.ckbapp.dev/indexer'
+
+# If a CKB indexer RPC url is explicitly specified, we assume that we are
+# connecting to a standalone indexer (i.e. we use get_tip).
+# Otherwise we just use CKB RPC url and assume that we are connecting to CKB
+# builtin indexer (i.e. we use get_indexer_tip).
+# indexer_url = 'standalone ckb-indexer, optional'
 
 [rpc_server]
 listen = '0.0.0.0:8119'

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -1,9 +1,14 @@
 node_mode = 'readonly'
 
-# To achieve higher sync speed, please run your own ckb-testnet-node and ckb-testnet-indexer
-# see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
+[p2p_network_config]
+# The domain name here should resolve to the IPv4 address of the full node.
+# And obviously readonly nodes need to be able to reach the TCP 8999 port of the full node.
+dial = ["/dns4/testnet.p2p.godwoken.io/tcp/8999"]
+
 [rpc_client]
 # Public Nodes (rate_limit: 20 req/s)
+# To achieve higher sync speed, please run your own ckb-testnet-node and ckb-testnet-indexer
+# see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
 ckb_url = 'https://testnet.ckbapp.dev/rpc'
 indexer_url = 'https://testnet.ckbapp.dev/indexer'
 

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -22,18 +22,18 @@ increase_max_l2_tx_cycles_to_500m = 825000
 [[fork.backend_forks]]
 fork_height = 0
 [[fork.backend_forks.backends]]
-validator_path = '/scripts/godwoken-scripts/meta-contract-validator'
-generator_path = '/scripts/godwoken-scripts/meta-contract-generator'
+validator_path = '/scripts/gwos-v1.3.0-rc1/meta-contract-validator'
+generator_path = '/scripts/gwos-v1.3.0-rc1/meta-contract-generator'
 validator_script_type_hash = '0x37b25df86ca495856af98dff506e49f2380d673b0874e13d29f7197712d735e8'
 backend_type = 'Meta'
 [[fork.backend_forks.backends]]
-validator_path = '/scripts/godwoken-scripts/sudt-validator'
-generator_path = '/scripts/godwoken-scripts/sudt-generator'
+validator_path = '/scripts/gwos-v1.3.0-rc1/sudt-validator'
+generator_path = '/scripts/gwos-v1.3.0-rc1/sudt-generator'
 validator_script_type_hash = '0xb6176a6170ea33f8468d61f934c45c57d29cdc775bcd3ecaaec183f04b9f33d9'
 backend_type = 'Sudt'
 [[fork.backend_forks.backends]]
-validator_path = '/scripts/godwoken-scripts/eth-addr-reg-validator'
-generator_path = '/scripts/godwoken-scripts/eth-addr-reg-generator'
+validator_path = '/scripts/gwos-v1.3.0-rc1/eth-addr-reg-validator'
+generator_path = '/scripts/gwos-v1.3.0-rc1/eth-addr-reg-generator'
 validator_script_type_hash = '0xa30dcbb83ebe571f49122d8d1ce4537679ebf511261c8ffaaa6679bf9fdea3a4'
 backend_type = 'EthAddrReg'
 [[fork.backend_forks.backends]]
@@ -151,7 +151,7 @@ args = '0x86c7429247beba7ddd6e4361bcdfc0510b0b644131e2afb7e486375249a01802'
 
 [debug]
 output_l1_tx_cycles = true
-expected_l1_tx_upper_bound_cycles = 70000000
+expected_l1_tx_upper_bound_cycles = 350000000
 debug_tx_dump_path = '/mnt/debug-tx-dump'
 enable_debug_rpc = false
 


### PR DESCRIPTION
## Notable Changes
- **Experimental gas-less feature** 
   Discussion: https://github.com/godwokenrises/godwoken/discussions/860 
   PR: 
      https://github.com/godwokenrises/godwoken/pull/869
      https://github.com/godwokenrises/godwoken-web3/pull/581
- an upgrading of on-chain scripts is included
  https://github.com/godwokenrises/godwoken/pull/836
  https://github.com/godwokenrises/godwoken/pull/883
  
- https://github.com/godwokenrises/godwoken/pull/907

## Release notes
More info, please refer to https://github.com/godwokenrises/godwoken/blob/develop/CHANGELOG.md or the detailed release notes:

- Godwoken Web3
   https://github.com/godwokenrises/godwoken-web3/releases
- Godwoken 
   https://github.com/godwokenrises/godwoken/releases

## Changed Configs
1. [enable the P2P syncing feature between external gw-readonly-node and gw-fullnode](https://github.com/godwokenrises/godwoken-info/pull/84/commits/e26f773d22ce3be312f5699430f31222826fb084) 
    The P2P syncing feature could improve the experience of an external Godwoken readonly node, such as GwScan and Ankr. An external Godwoken readonly node can receive layer-2 block sync messages from fullnode through the configured `p2p_network`.

2. [Set the paths of godwoken-scripts to `/scripts/gwos-v1.3.0-rc1` to make the backend versions clearer](https://github.com/godwokenrises/godwoken-info/pull/84/files#diff-7e686c21daa843938ca4c0df5db2fe3b79bdb6e1845d19659f941f0a811e0976R31-R42)

3. [support CKB build-in indexer](https://github.com/godwokenrises/godwoken-info/pull/84/commits/31ea08694ccd53dc95612438b916fd17a9b213cb)
    If a CKB indexer RPC url is explicitly specified, we assume that we are connecting to a standalone indexer (i.e. we use get_tip). Otherwise we just use CKB RPC url and assume that we are connecting to CKB builtin indexer (i.e. we use get_indexer_tip).

<!--
## Inspect the component versions in the image
```bash
docker inspect ghcr.io/godwokenrises/godwoken-prebuilds:xxxx | egrep ref.component

    # components
    ...
```
-->
