### PR TITLE
mainnet_v1: bump to godwokenrises/godwoken:1.7.4-poly.1.5.1

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 services:
   gw-readonly:
     container_name: gw-mainnet_v1-readonly
-    image: ghcr.io/godwokenrises/godwoken-prebuilds:1.7.3
+    image: ghcr.io/godwokenrises/godwoken:1.7.4-poly.1.5.1
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh
@@ -47,7 +47,7 @@ services:
     - mainnet_v1-redis-data:/data
 
   web3:
-    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.9.0
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.9.3
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -64,7 +64,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.9.0
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.9.3
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     - ./chain-data/logs:/var/lib/web3-indexer/logs

--- a/mainnet_v1/gw-mainnet_v1-config-readonly.toml
+++ b/mainnet_v1/gw-mainnet_v1-config-readonly.toml
@@ -10,6 +10,11 @@ ckb_url = 'https://mainnet.ckb.dev/rpc'
 listen = '0.0.0.0:8119'
 enable_methods = []
 
+# The P2P syncing feature could improve the experience of an external Godwoken readonly node.
+# An external Godwoken readonly node can receive layer-2 block sync messages from fullnode through
+# the configured p2p_network.
+#
+# see also: https://github.com/godwokenrises/godwoken/blob/develop/docs/p2p_sync.md
 [p2p_network_config]
 dial = ["/dns4/mainnet.p2p.godwoken.io/tcp/9999"]
 

--- a/mainnet_v1/gw-mainnet_v1-config-readonly.toml
+++ b/mainnet_v1/gw-mainnet_v1-config-readonly.toml
@@ -10,8 +10,8 @@ ckb_url = 'https://mainnet.ckb.dev/rpc'
 listen = '0.0.0.0:8119'
 enable_methods = []
 
-# [p2p_network_config]
-# dial = ["/dns4/godwoken/tcp/9999"]
+[p2p_network_config]
+dial = ["/dns4/mainnet.p2p.godwoken.io/tcp/9999"]
 
 
 [fork]

--- a/mainnet_v1/gw-mainnet_v1-config-readonly.toml
+++ b/mainnet_v1/gw-mainnet_v1-config-readonly.toml
@@ -3,7 +3,7 @@ node_mode = 'readonly'
 # Note: It is better to run your own CKB mainnet node.
 # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker/#run-a-ckb-mainnet-node
 [rpc_client]
-indexer_url = 'https://mainnet.ckb.dev/indexer'
+indexer_url = 'CKB_STANDALONE_INDEXER'
 ckb_url = 'https://mainnet.ckb.dev/rpc'
 
 [rpc_server]
@@ -61,6 +61,14 @@ fork_height = 233000
 # https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.5.0
 validator_path = '/scripts/godwoken-polyjuice-v1.5.0/validator'
 generator_path = '/scripts/godwoken-polyjuice-v1.5.0/generator'
+validator_script_type_hash = '0x83d5d8841518e8db686909d27c821398491f475ed5f1cd392c36e83f4252c4ac'
+backend_type = 'Polyjuice'
+
+[[fork.backend_forks]]
+fork_height = 304440
+[[fork.backend_forks.backends]]
+validator_path = '/scripts/godwoken-polyjuice-v1.5.1/validator'
+generator_path = '/scripts/godwoken-polyjuice-v1.5.1/generator'
 validator_script_type_hash = '0x83d5d8841518e8db686909d27c821398491f475ed5f1cd392c36e83f4252c4ac'
 backend_type = 'Polyjuice'
 

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -1,5 +1,10 @@
 node_mode = 'readonly'
 
+# The P2P syncing feature could improve the experience of an external Godwoken readonly node.
+# An external Godwoken readonly node can receive layer-2 block sync messages from fullnode through
+# the configured p2p_network.
+#
+# see also: https://github.com/godwokenrises/godwoken/blob/develop/docs/p2p_sync.md
 [p2p_network_config]
 # The domain name here should resolve to the IPv4 address of the full node.
 # And obviously readonly nodes need to be able to reach the TCP 8999 port of the full node.


### PR DESCRIPTION
## Release notes
- Godwoken Web3
   https://github.com/godwokenrises/godwoken-web3/releases/tag/v1.9.1
   https://github.com/godwokenrises/godwoken-web3/releases/tag/v1.9.2
   https://github.com/godwokenrises/godwoken-web3/releases/tag/v1.9.3
- Godwoken 
   https://github.com/godwokenrises/godwoken/releases/tag/v1.7.4


## Changed Configs
1. enable the P2P syncing feature between external gw-readonly-node and gw-fullnode
    The P2P syncing feature could improve the experience of an external Godwoken readonly node, such as GwScan and Ankr. An external Godwoken readonly node can receive layer-2 block sync messages from fullnode through the configured p2p_network.
    ```toml
    [p2p_network_config]
    dial = ["/dns4/mainnet.p2p.godwoken.io/tcp/9999"]
    ```

2. add backend_forks at block#304440
    ```toml
    [[fork.backend_forks]]
    fork_height = 304440
    [[fork.backend_forks.backends]]
    validator_path = '/scripts/godwoken-polyjuice-v1.5.1/validator'
    generator_path = '/scripts/godwoken-polyjuice-v1.5.1/generator'
    validator_script_type_hash = '0x83d5d8841518e8db686909d27c821398491f475ed5f1cd392c36e83f4252c4ac'
    backend_type = 'Polyjuice'
    ```

<!--
## Inspect the component versions in the image
```bash
docker inspect ghcr.io/godwokenrises/godwoken-prebuilds:xxxx | egrep ref.component

    # components
    ...
```
-->
