### PR TITLE
chore: `rewind-to-last-valid-block` before starting gw-readonly-node

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -24,7 +24,11 @@ services:
     environment:
     # other log envs: ,gw_generator=debug,gw_chain=debug
     - RUST_LOG=info
-    command: godwoken
+    command: |
+      bash -c 'set -ex
+        godwoken rewind-to-last-valid-block --config-path /deploy/config.toml
+        godwoken run -c /deploy/config.toml
+      '
     deploy:
       restart_policy:
         condition: on-failure

--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -27,7 +27,11 @@ services:
     environment:
     # other log envs: ,gw_generator=debug,gw_chain=debug
     - RUST_LOG=info
-    command: godwoken
+    command: |
+      bash -c 'set -ex
+        godwoken rewind-to-last-valid-block --config-path /deploy/config.toml
+        godwoken run -c /deploy/config.toml
+      '
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
If an external node is not updated in time, it may encounter `fork detected` warning or even `bad block` error.

So, I think we should add 
`godwoken rewind-to-last-valid-block --config-path /deploy/config.toml` 
into the init step of a Godwoken readonly node.
