### PR TITLE
testnet_v1: bump to Godwoken v1.12.0-rc2-smt-trie and Web3/Indexer 1.12-rc

### DIFF
--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     - testnet_v1-redis-data:/data
 
   web3:
-    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.12.0-rc1
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:1.12-rc
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -77,7 +77,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.12.0-rc1
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:1.12-rc
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     - ./chain-data/logs:/var/lib/web3-indexer/logs

--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
   gw-readonly:
     container_name: gw-testnet_v1-readonly
-    image: ghcr.io/godwokenrises/godwoken:1.12-rc-smt-trie
+    image: ghcr.io/godwokenrises/godwoken:v1.12.0-rc2-smt-trie
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh

--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -35,8 +35,9 @@ services:
         # some bad blocks accidentally due to e.g. version/configuration differences.
         # see also: https://github.com/godwokenrises/godwoken/pull/832
         # godwoken rewind-to-last-valid-block --config-path /deploy/config.toml
-        #migrated execute
-        #godwoken run -c /deploy/config.toml
+
+        # Run Godwoken
+        godwoken run -c /deploy/config.toml
       '
     deploy:
       restart_policy:

--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
   gw-readonly:
     container_name: gw-testnet_v1-readonly
-    image: ghcr.io/godwokenrises/godwoken:v1.8.0-rc3
+    image: ghcr.io/godwokenrises/godwoken:1.12-rc-smt-trie
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh
@@ -29,8 +29,14 @@ services:
     - RUST_LOG=info
     command: |
       bash -c 'set -ex
-        godwoken rewind-to-last-valid-block --config-path /deploy/config.toml
-        godwoken run -c /deploy/config.toml
+        # migrate command for SMT trie feature, only needs to be run on first activation
+        godwoken migrate --config /deploy/config.toml | tee -a /mnt/smt-migrate.log
+        # use this command to rewind the chain to the last valid block, if the node has encountered
+        # some bad blocks accidentally due to e.g. version/configuration differences.
+        # see also: https://github.com/godwokenrises/godwoken/pull/832
+        # godwoken rewind-to-last-valid-block --config-path /deploy/config.toml
+        #migrated execute
+        #godwoken run -c /deploy/config.toml
       '
     deploy:
       restart_policy:
@@ -54,7 +60,7 @@ services:
     - testnet_v1-redis-data:/data
 
   web3:
-    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.10.0-rc1
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.12.0-rc1
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -71,7 +77,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.10.0-rc1
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.12.0-rc1
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     - ./chain-data/logs:/var/lib/web3-indexer/logs

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -27,138 +27,11 @@ ckb_url = 'https://testnet.ckbapp.dev/rpc'
 listen = '0.0.0.0:8119'
 enable_methods = []
 
-[fork]
-increase_max_l2_tx_cycles_to_500m = 825000
-
-[[fork.backend_forks]]
-fork_height = 0
-[[fork.backend_forks.backends]]
-validator_path = '/scripts/gwos-v1.3.0-rc1/meta-contract-validator'
-generator_path = '/scripts/gwos-v1.3.0-rc1/meta-contract-generator'
-validator_script_type_hash = '0x37b25df86ca495856af98dff506e49f2380d673b0874e13d29f7197712d735e8'
-backend_type = 'Meta'
-[[fork.backend_forks.backends]]
-validator_path = '/scripts/gwos-v1.3.0-rc1/sudt-validator'
-generator_path = '/scripts/gwos-v1.3.0-rc1/sudt-generator'
-validator_script_type_hash = '0xb6176a6170ea33f8468d61f934c45c57d29cdc775bcd3ecaaec183f04b9f33d9'
-backend_type = 'Sudt'
-[[fork.backend_forks.backends]]
-validator_path = '/scripts/gwos-v1.3.0-rc1/eth-addr-reg-validator'
-generator_path = '/scripts/gwos-v1.3.0-rc1/eth-addr-reg-generator'
-validator_script_type_hash = '0xa30dcbb83ebe571f49122d8d1ce4537679ebf511261c8ffaaa6679bf9fdea3a4'
-backend_type = 'EthAddrReg'
-[[fork.backend_forks.backends]]
-validator_path = '/scripts/godwoken-polyjuice-v1.1.5-beta/validator'
-generator_path = '/scripts/godwoken-polyjuice-v1.1.5-beta/generator'
-validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
-backend_type = 'Polyjuice'
-
-[[fork.backend_forks]]
-fork_height = 110000
-[[fork.backend_forks.backends]]
-validator_path = '/scripts/godwoken-polyjuice-v1.2.0/validator'
-generator_path = '/scripts/godwoken-polyjuice-v1.2.0/generator'
-validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
-backend_type = 'Polyjuice'
-
-[[fork.backend_forks]]
-fork_height = 180000
-# Polyjuice v1.4.0 is backward compatible with Polyjuice v1.3
-# https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.0
-[[fork.backend_forks.backends]]
-validator_path = '/scripts/godwoken-polyjuice-v1.4.0/validator'
-generator_path = '/scripts/godwoken-polyjuice-v1.4.0/generator'
-validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
-backend_type = 'Polyjuice'
-
-[[fork.backend_forks]]
-fork_height = 380000
-# https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.1
-[[fork.backend_forks.backends]]
-validator_path = '/scripts/godwoken-polyjuice-v1.4.1/validator'
-generator_path = '/scripts/godwoken-polyjuice-v1.4.1/generator_log'
-validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
-backend_type = 'Polyjuice'
-
-[[fork.backend_forks]]
-fork_height = 630000
-# https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.4.5
-[[fork.backend_forks.backends]]
-validator_path = '/scripts/godwoken-polyjuice-v1.4.5/validator'
-generator_path = '/scripts/godwoken-polyjuice-v1.4.5/generator'
-validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
-backend_type = 'Polyjuice'
-
-[[fork.backend_forks]]
-fork_height = 825000
-# https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/1.5.0
-[[fork.backend_forks.backends]]
-validator_path = '/scripts/godwoken-polyjuice-v1.5.0/validator'
-generator_path = '/scripts/godwoken-polyjuice-v1.5.0/generator'
-validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
-backend_type = 'Polyjuice'
-
-
-[genesis]
-timestamp = 1651979802446
-rollup_type_hash = '0x702359ea7f073558921eb50d8c1c77e92f760c8f8656bde4995f26b8963e2dd8'
-meta_contract_validator_type_hash = '0x37b25df86ca495856af98dff506e49f2380d673b0874e13d29f7197712d735e8'
-eth_registry_validator_type_hash = '0xa30dcbb83ebe571f49122d8d1ce4537679ebf511261c8ffaaa6679bf9fdea3a4'
-
-[genesis.rollup_config]
-l1_sudt_script_type_hash = '0xc5e5dcf215925f7ef4dfaf5f4b4f105bc321c02776d6e7d52a1db3fcd9d011a4'
-custodian_script_type_hash = '0x85ae4db0dd83f428a31deb342e4000af37ce2c9645d9e619df00096e3c50a2bb'
-deposit_script_type_hash = '0x50704b84ecb4c4b12b43c7acb260ddd69171c21b4c0ba15f3c469b7d143f6f18'
-withdrawal_script_type_hash = '0x06ae0706bb2d7997d66224741d3ec7c173dbb2854a6d2cf97088796b677269c6'
-challenge_script_type_hash = '0x5a86c3bf1e8648b6a6f8abe6875720ccf9745ab225b68fa7c195f9d6635dea80'
-stake_script_type_hash = '0x7f5a09b8bd0e85bcf2ccad96411ccba2f289748a1c16900b0635c2ed9126f288'
-l2_sudt_validator_script_type_hash = '0xb6176a6170ea33f8468d61f934c45c57d29cdc775bcd3ecaaec183f04b9f33d9'
-burn_lock_hash = '0x77c93b0632b5b6c3ef922c5b7cea208fb0a7c427a13d50e13d3fefad17e0c590'
-required_staking_capacity = '0x3691d6afc000'
-challenge_maturity_blocks = '0x1c2'
-finality_blocks = '0x64'
-reward_burn_rate = '0x32'
-chain_id = '0x116e9'
-
-[[genesis.rollup_config.allowed_eoa_type_hashes]]
-type_ = 'eth'
-hash = '0x07521d0aa8e66ef441ebc31204d86bb23fc83e9edc58c19dbb1b0ebe64336ec0'
-
-[[genesis.rollup_config.allowed_contract_type_hashes]]
-type_ = 'meta'
-hash = '0x37b25df86ca495856af98dff506e49f2380d673b0874e13d29f7197712d735e8'
-
-[[genesis.rollup_config.allowed_contract_type_hashes]]
-type_ = 'sudt'
-hash = '0xb6176a6170ea33f8468d61f934c45c57d29cdc775bcd3ecaaec183f04b9f33d9'
-
-[[genesis.rollup_config.allowed_contract_type_hashes]]
-type_ = 'polyjuice'
-hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
-
-[[genesis.rollup_config.allowed_contract_type_hashes]]
-type_ = 'eth_addr_reg'
-hash = '0xa30dcbb83ebe571f49122d8d1ce4537679ebf511261c8ffaaa6679bf9fdea3a4'
-
-[genesis.secp_data_dep]
-dep_type = 'code'
-
-[genesis.secp_data_dep.out_point]
-tx_hash = '0x8f8c79eb6671709633fe6a46de93c0fedc9c1b8a6527a18d3983879542635c9f'
-index = '0x3'
-
-[chain]
-skipped_invalid_block_list = []
-
-[chain.genesis_committed_info]
-number = '0x50c48d'
-block_hash = '0x605e5f4b14c32865a9e7d5fa1f713a114ec114b4a9d629a698dc1caf9c2b80f2'
-transaction_hash = '0xc25c554eab6483a35f18db3fa183c7205d7e19973591847419826e181b787432'
-
-[chain.rollup_type_script]
-code_hash = '0x1e44736436b406f8e48a30dfbddcf044feb0c9eebfe63b0f81cb5bb727d84854'
-hash_type = 'type'
-args = '0x86c7429247beba7ddd6e4361bcdfc0510b0b644131e2afb7e486375249a01802'
+# builtin consensus config
+# see https://github.com/godwokenrises/godwoken/pull/946
+[consensus]
+# https://github.com/godwokenrises/godwoken/blob/develop/crates/config/src/consensus/builtins/testnet.toml
+builtin = 'Testnet'
 
 [debug]
 output_l1_tx_cycles = true
@@ -170,24 +43,13 @@ enable_debug_rpc = false
 check_mem_block_before_submit = false
 
 [block_producer.block_producer]
-registry_id = 2
+address_type = "Eth"
 address = '0x715ab282b873b79a7be8b0e8c13c4e8966a52040'
 
-[block_producer.rollup_config_cell_dep]
-dep_type = 'code'
-
-[block_producer.rollup_config_cell_dep.out_point]
-tx_hash = '0xcd52d714ddea04d2917892f16d47cbd0bbbb7d9ba281233ec4021f79fc34bccc'
-index = '0x0'
 [block_producer.challenger_config.rewards_receiver_lock]
 code_hash = '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8'
 hash_type = 'type'
 args = '0x699d2dd60134ddf8979df6005d9530929c8a72e1'
-
-[block_producer.challenger_config.burn_lock]
-code_hash = '0x0000000000000000000000000000000000000000000000000000000000000000'
-hash_type = 'data'
-args = '0x'
 
 [mem_pool]
 execute_l2tx_max_cycles = 500000000
@@ -206,79 +68,17 @@ max_cycles_limit = '1950000000'
 # https://github.com/godwokenrises/godwoken/blob/v1.7.0/crates/config/src/config.rs#L579-L599
 
 [store]
-path = '/mnt/store-20221008.db'
+# The data directory of the existing node is replaced
+path = '/mnt/testnet-20230215.rocksdb'
 options_file = '/deploy/db.toml'
 cache_size = 536870912
-[store.options]
 
-[consensus.contract_type_scripts.state_validator]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0x063555cc66a1c270aafbe9324718232289a462f4d9edfc7a57f9c6e0f8257669'
-
-[consensus.contract_type_scripts.deposit_lock]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0x86d24e5cb132478005dcf2b59680a9f37011cb54a5947f42f19ba5076bc6594d'
-
-[consensus.contract_type_scripts.stake_lock]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0x0fc0f22f9a6e000692159c9d5dc633fba7ffcd1f1f2218d23aa2ede96f4b471d'
-
-[consensus.contract_type_scripts.custodian_lock]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0xc4695745c69c298c89bc701b6cc8614332c6fd8a2ed160e04748fc6fda636e71'
-
-[consensus.contract_type_scripts.withdrawal_lock]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0xbfef6580c1f93b98fa7d33bb3faa63255caba9bfbebfbada5eab4ce195052b9f'
-
-[consensus.contract_type_scripts.challenge_lock]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0x7997689a9038a5487535cd8297d37b39840e140c849efd6f07ecc20ee9b9c244'
-
-[consensus.contract_type_scripts.l1_sudt]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0x4db75e03349f4f2ec792476035dd1b7376c683130f7e2e74024be2d9ee064511'
-
-[consensus.contract_type_scripts.omni_lock]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0x1b8572b16c07f46a0efed623aea6de05d45985b9a7c1b0b52276da5d9f9615b7'
-[consensus.contract_type_scripts.allowed_eoa_scripts.0x07521d0aa8e66ef441ebc31204d86bb23fc83e9edc58c19dbb1b0ebe64336ec0]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0x66056785e4e989729053508c30d620ead06b377f600eedc0419e6858e459ccfa'
-[consensus.contract_type_scripts.allowed_contract_scripts.0xa30dcbb83ebe571f49122d8d1ce4537679ebf511261c8ffaaa6679bf9fdea3a4]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0x05b2bda117f8e8ca452952b49bb301229a25a1e15bb893efa643308920f3d123'
-
-[consensus.contract_type_scripts.allowed_contract_scripts.0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0xe953b6bafee807fd85bfd0520339379fcdfad8bb07f0140f517e89f7cb4b7a0c'
-
-[consensus.contract_type_scripts.allowed_contract_scripts.0xb6176a6170ea33f8468d61f934c45c57d29cdc775bcd3ecaaec183f04b9f33d9]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0xe9374fd920cd4144ce72ab7ef3405d89e5f8530d586ba986e993f1d285060a7a'
-
-[consensus.contract_type_scripts.allowed_contract_scripts.0x37b25df86ca495856af98dff506e49f2380d673b0874e13d29f7197712d735e8]
-code_hash = '0x00000000000000000000000000000000000000000000000000545950455f4944'
-hash_type = 'type'
-args = '0xda1784f90499ba4e5892da631ee4220c9113f38e5b2a881d0a58248123184496'
-[dynamic_config.fee_config]
+[mem_pool.fee]
 meta_cycles_limit = 20000
 sudt_cycles_limit = 20000
 eth_addr_reg_cycles_limit = 20000
 withdraw_cycles_limit = 20000
 
-[dynamic_config.rpc_config]
+[mem_pool.extra]
 allowed_sudt_proxy_creator_account_id = []
 sudt_proxy_code_hashes = []

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -68,8 +68,7 @@ max_cycles_limit = '1950000000'
 # https://github.com/godwokenrises/godwoken/blob/v1.7.0/crates/config/src/config.rs#L579-L599
 
 [store]
-# The data directory of the existing node is replaced
-path = '/mnt/testnet-20230215.rocksdb'
+path = '/mnt/store-20221008.db'
 options_file = '/deploy/db.toml'
 cache_size = 536870912
 


### PR DESCRIPTION
## Notable Changes
- Highlights
   - Builtin mainnet and testnet consensus config https://github.com/godwokenrises/godwoken/pull/946
      The consensus-related options were moved into consensus config, and the builtin testnet and mainnet consensus were put into the godwoken binary. This change reduces the operation works of node maintainers

      **~200 lines of Godwoken node [config](https://github.com/godwokenrises/godwoken-info/blob/8eea5d5925d03b0c64eadf23cca40b267f085ef4/testnet_v1_1/gw-testnet_v1-config-readonly.toml) was reduced,** from 284 lines to 84 lines.

- Enhancement:
  - chore: use TransactionDB and refactor store https://github.com/godwokenrises/godwoken/pull/903
  - chore: refactor RPC server https://github.com/godwokenrises/godwoken/pull/927
  - Improve the error code of API when executing transactions https://github.com/godwokenrises/godwoken/pull/930

- Note:
   - To enable SMT-trie feature, data migration is required for this upgrade.  It takes about 75 minutes
      ```bash
        # migrate command for SMT trie feature, only needs to be run on first activation
        godwoken migrate --config /deploy/config.toml | tee -a /mnt/smt-migrate.log
      ``` 
  
## Detailed Release notes
   - Godwoken
      https://github.com/godwokenrises/godwoken/releases

  - Godwoken-web3
     https://github.com/godwokenrises/godwoken-web3/releases
  

## Changed Configs
1.  introduced testnet builtin consensus config
   ```TOML
    # builtin consensus config
    # see https://github.com/godwokenrises/godwoken/pull/946
    [consensus]
    # https://github.com/godwokenrises/godwoken/blob/develop/crates/config/src/consensus/builtins/testnet.toml
    builtin = 'Testnet'
   ```

2. [[dynamic_config.fee_config] -> [mem_pool.fee]](https://github.com/godwokenrises/godwoken-info/pull/88/files#diff-7e686c21daa843938ca4c0df5db2fe3b79bdb6e1845d19659f941f0a811e0976R76)

3. [[dynamic_config.rpc_config] -> [mem_pool.extra]](https://github.com/godwokenrises/godwoken-info/pull/88/files#diff-7e686c21daa843938ca4c0df5db2fe3b79bdb6e1845d19659f941f0a811e0976R82)

<!--
## Inspect the component versions in the image
```bash
docker inspect ghcr.io/godwokenrises/godwoken-prebuilds:xxxx | egrep ref.component

    # components 
```

-->
