### PR TITLE
testnet: update PRICE_ORACLE config in web3.env

### DIFF
--- a/testnet_v1_1/web3.env
+++ b/testnet_v1_1/web3.env
@@ -16,3 +16,15 @@ GODWOKEN_READONLY_JSON_RPC=http://gw-readonly:8119
 
 # eth_estimateGas will add this number to result, optional, default to 0
 EXTRA_ESTIMATE_GAS=30000
+
+# ENABLE_PRICE_ORACLE=<optional, boolean, decide if use dynamic gas price based on CKB price oracle, default to false>
+# GAS_PRICE_DIVIDER=<optional, a system value to adjust gasPrice with ckbPrice, default to 76000000000000000 (0.00002pCKB with 0.0038 ckb price)>
+# **MIN_GAS_PRICE = GAS_PRICE_DIVIDER / ckbPrice**
+# see also: https://github.com/nervosnetwork/godwoken-web3/pull/514
+ENABLE_PRICE_ORACLE=true
+GAS_PRICE_DIVIDER=150000000000000
+# uint pCKB, equals 1 shannon/gas
+MIN_GAS_PRICE_LOWER_LIMIT=0.00000001
+# uint pCKB, equals 6 shannon/gas
+MIN_GAS_PRICE_UPPER_LIMIT=0.00000006
+# The range of MIN_GAS_PRICE = [0.00000001 pCKB, 0.00000006 pCKB]


### PR DESCRIPTION
```env
# ENABLE_PRICE_ORACLE=<optional, boolean, decide if use dynamic gas price based on CKB price oracle, default to false>
# GAS_PRICE_DIVIDER=<optional, a system value to adjust gasPrice with ckbPrice, default to 76000000000000000 (0.00002pCKB with 0.0038 ckb price)>
# **MIN_GAS_PRICE = GAS_PRICE_DIVIDER / ckbPrice**
# see also: https://github.com/nervosnetwork/godwoken-web3/pull/514
ENABLE_PRICE_ORACLE=true
GAS_PRICE_DIVIDER=150000000000000
# uint pCKB, equals 1 shannon/gas
MIN_GAS_PRICE_LOWER_LIMIT=0.00000001
# uint pCKB, equals 6 shannon/gas
MIN_GAS_PRICE_UPPER_LIMIT=0.00000006
# The range of MIN_GAS_PRICE = [0.00000001 pCKB, 0.00000006 pCKB]
```