### PR TITLE
mainnet_v1: bump to Godwoken 1.14.0-smt-trie and web3/indexer 1.14.0

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 services:
   gw-readonly:
     container_name: gw-mainnet_v1-readonly
-    image: ghcr.io/godwokenrises/godwoken:v1.13.0
+    image: ghcr.io/godwokenrises/godwoken:v1.14.0-smt-trie
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh
@@ -56,7 +56,7 @@ services:
     - mainnet_v1-redis-data:/data
 
   web3:
-    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.13.0
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.14.0
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -73,7 +73,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.13.0
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.14.0
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     - ./chain-data/logs:/var/lib/web3-indexer/logs

--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -26,6 +26,9 @@ services:
     - RUST_LOG=info
     command: |
       bash -c 'set -ex
+        # migrate command for SMT trie feature, only needs to be run on first activation
+        godwoken migrate --config /deploy/config.toml | tee -a /mnt/smt-migrate.log
+
         # use this command to rewind the chain to the last valid block, if the node has encountered
         # some bad blocks accidentally due to e.g. version/configuration differences.
         # see also: https://github.com/godwokenrises/godwoken/pull/832


### PR DESCRIPTION
## Features:

- https://github.com/godwokenrises/godwoken/pull/1060

## Bug fixes:

- https://github.com/godwokenrises/godwoken/pull/1073
- https://github.com/godwokenrises/godwoken/pull/1066
- https://github.com/godwokenrises/godwoken/pull/1063
- https://github.com/godwokenrises/godwoken/pull/1076

## Release notes
- Godwoken 
   https://github.com/godwokenrises/godwoken/releases



## Note
The image `ghcr.io/godwokenrises/godwoken:v1.14.0-smt-trie` will enable SMT-trie feature, which **will greatly decrease the amount of store read/write operations needed to update SMTs, thus improving transaction throughput and block syncing speed**. SMT roots and proofs won't change.

To enable SMT-trie feature, data migration for `gw-readonly-node` is required for this upgrade.
```bash
  # gw-readonly-node
  # migrate command for SMT trie feature, only needs to be run on first activation
  godwoken migrate --config /deploy/config.toml | tee -a /mnt/smt-migrate.log
``` 

