### PR TITLE
testnet_v1: bump Godwoken to v1.15.0

### DIFF
--- a/testnet_v1_1/docker-compose.yml
+++ b/testnet_v1_1/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker#run-a-ckb-testnet-node
   gw-readonly:
     container_name: gw-testnet_v1-readonly
-    image: ghcr.io/godwokenrises/godwoken:v1.14.0-smt-trie
+    image: ghcr.io/godwokenrises/godwoken:v1.15.0-smt-trie
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh
@@ -61,7 +61,7 @@ services:
     - testnet_v1-redis-data:/data
 
   web3:
-    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.14.0
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.15.0
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -78,7 +78,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.14.0
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.15.0
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     - ./chain-data/logs:/var/lib/web3-indexer/logs

--- a/testnet_v1_1/gw-testnet_v1-config-readonly.toml
+++ b/testnet_v1_1/gw-testnet_v1-config-readonly.toml
@@ -17,12 +17,6 @@ dial = ["/dns4/testnet.p2p.godwoken.io/tcp/8999"]
 # Public Nodes (rate_limit: 20 req/s)
 ckb_url = 'https://testnet.ckbapp.dev/rpc'
 
-# If a CKB indexer RPC url is explicitly specified, we assume that we are
-# connecting to a standalone indexer (i.e. we use get_tip).
-# Otherwise we just use CKB RPC url and assume that we are connecting to CKB
-# builtin indexer (i.e. we use get_indexer_tip).
-# indexer_url = 'standalone ckb-indexer, optional'
-
 [rpc_server]
 listen = '0.0.0.0:8119'
 enable_methods = []


### PR DESCRIPTION
## Notable Changes
1. chore: update ckb deps for the upcoming ckb2023 hardfork by @blckngm in https://github.com/godwokenrises/godwoken/pull/1106

### no configuration change

## Release notes
- https://github.com/godwokenrises/godwoken/releases/tag/v1.15.0
