### PR TITLE
mainnet_v1: bump Godwoken to v1.15.0

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 services:
   gw-readonly:
     container_name: gw-mainnet_v1-readonly
-    image: ghcr.io/godwokenrises/godwoken:v1.14.0-smt-trie
+    image: ghcr.io/godwokenrises/godwoken:v1.15.0-smt-trie
     expose: [8119, 8219]
     healthcheck:
       test: /bin/gw-healthcheck.sh
@@ -59,7 +59,7 @@ services:
     - mainnet_v1-redis-data:/data
 
   web3:
-    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.14.0
+    image: ghcr.io/godwokenrises/godwoken-web3-prebuilds:v1.15.0
     healthcheck:
       test: curl http://127.0.0.1:8024 || exit 1
     volumes:
@@ -76,7 +76,7 @@ services:
         condition: service_healthy
 
   web3-indexer:
-    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.14.0
+    image: ghcr.io/godwokenrises/godwoken-web3-indexer-prebuilds:v1.15.0
     volumes:
     - ./web3-indexer-config.toml:/var/lib/web3-indexer/indexer-config.toml
     - ./chain-data/logs:/var/lib/web3-indexer/logs

--- a/mainnet_v1/gw-mainnet_v1-config-readonly.toml
+++ b/mainnet_v1/gw-mainnet_v1-config-readonly.toml
@@ -4,11 +4,6 @@ node_mode = 'readonly'
 # see: https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker/#run-a-ckb-mainnet-node
 [rpc_client]
 ckb_url = 'https://mainnet.ckb.dev/rpc'
-# If a CKB indexer RPC url is explicitly specified, we assume that we are
-# connecting to a standalone indexer (i.e. we use get_tip).
-# Otherwise we just use CKB RPC url and assume that we are connecting to CKB
-# builtin indexer (i.e. we use get_indexer_tip).
-# indexer_url = 'standalone ckb-indexer, optional'
 
 [rpc_server]
 listen = '0.0.0.0:8119'


### PR DESCRIPTION
## Notable Changes
1. chore: update ckb deps for the upcoming ckb2023 hardfork by @blckngm 
   in https://github.com/godwokenrises/godwoken/pull/1106
2. The CKB node connected by the Godwoken-readonly-node is recommended to upgrade to https://github.com/nervosnetwork/ckb/releases/tag/v0.112.1

### no configuration change

## Release notes
- https://github.com/godwokenrises/godwoken/releases/tag/v1.15.0
